### PR TITLE
Remove pre-commit install from "Your first contribution to PyMC" page

### DIFF
--- a/sprint/docstring_tutorial.md
+++ b/sprint/docstring_tutorial.md
@@ -274,7 +274,6 @@ Successfully installed pymc-4.0.0b2
 Then activate `pre-commit`. It will help auto formatting the code for you.
 
 ```bash
-pip install pre-commit
 pre-commit install
 ```
 on success will show


### PR DESCRIPTION
Remove pre-commit install from `docstring_tutorial.md` since it is already installed in the [conda environment](https://github.com/pymc-devs/pymc/blob/11e69ea9f7b8aaf3f1b3a166fe568765ef0cd4b0/conda-envs/environment-dev-py38.yml#L21).