### PR TITLE
take 1: social media kit text

### DIFF
--- a/2022-07_sprint/sprint_parties/community_partners.md
+++ b/2022-07_sprint/sprint_parties/community_partners.md
@@ -5,7 +5,7 @@
 
 Community Partners are organizations who support our mission and share our event for outreach.  Data Umbrella will add the Name, Logo and Website Link to this page to bring visibility to your community.  If you would like to be a community partner, please contact us ({{ du_email }}).
 
-We are providing a [Social Media Kit](media_kit) with information for sharing with your community. 
+We are providing a {ref}`media_kit` with information for sharing with your community.
 
 ## Community Partners
 

--- a/2022-07_sprint/sprint_parties/community_partners.md
+++ b/2022-07_sprint/sprint_parties/community_partners.md
@@ -5,32 +5,7 @@
 
 Community Partners are organizations who support our mission and share our event for outreach.  Data Umbrella will add the Name, Logo and Website Link to this page to bring visibility to your community.  If you would like to be a community partner, please contact us ({{ du_email }}).
 
-Our event series can be shared in one or more of the following ways:  
-- Event website: https://pymc-data-umbrella.xyz/en/latest/
-- Event registration form:  https://tinyurl.com/du-pymc-os-ws
-- Tweet:  https://twitter.com/DataUmbrella/status/1538875289652142080
-- LinkedIn post: ​​https://www.linkedin.com/feed/update/urn:li:activity:6944647561630662656/
-- Social media card:  https://raw.githubusercontent.com/pymc-devs/pymc-data-umbrella/main/_static/banner_2022_07/2022_07_banner_1280×640px.png
-- Meetup event: can share links or cross-post the event with your Meetup group
-    - Pre-series Office Hours | Jul 2 (Saturday) | 13 UTC | 1 hour | [MeetUp](https://www.meetup.com/data-umbrella/events/286552154/)
-    - Working Session #1      | Jul 9 (Saturday) | 13 UTC | 3 hours| [MeetUp](https://www.meetup.com/data-umbrella/events/286552452/)
-    - Working Session #2      | Jul 22 (Friday)  | 16 UTC | 3 hours| [MeetUp](https://www.meetup.com/data-umbrella/events/286628677/)
-    - Working Session #3      | Aug 4/5 (Th/Fr)  | 23 UTC  | 3 hours | [MeetUp](https://www.meetup.com/data-umbrella/events/286628723/)
-    - Post-series Office Hours [^1] | Aug 18 (Sat) | 23 UTC| 1 hour  | [MeetUp](https://www.meetup.com/data-umbrella/events/286628791/)
-- Via Slack, Discord, Facebook
-- Email copy (button to copy all text available at the top right of the code block)
-
-  ```none
-  We [insert org name] are excited to share that we are a Community Partner with Data Umbrella for their upcoming open source working sessions with the Python library PyMC.  PyMC is an open-source probabilistic programming language in Python.
-
-  This is a beginner-friendly event.  Skills that are helpful to have: Git, GitHub, Markdown, Sphinx, statistics, python, Bayesian statistics.
-
-  Additionally, we have a series of videos where participants can watch videos and add timestamps. There are lots of ways to participate and contribute to open source.
-
-  More information on joining the event:
-  a) Schedule of events: https://pymc-data-umbrella.xyz/en/latest/2022-07_sprint/schedule.html
-  b) Complete this registration form: https://tinyurl.com/du-pymc-os-ws
-  ```
+We are providing a [Social Media Kit](media_kit) with information for sharing with your community. 
 
 ## Community Partners
 

--- a/2022-07_sprint/sprint_parties/media_kit.md
+++ b/2022-07_sprint/sprint_parties/media_kit.md
@@ -1,17 +1,20 @@
+(media_kit)=
 # Social Media Kit
 
-(media_kit)=
-
 ## Event Hashtag
+This is our official hashtag and can be used on social media (Twitter, LinkedIn, Instagram, etc.)
 
-#DataUmbrellaPyMCSprint
+:::{div} sd-text-center sd-fs-3
+#DataUmbrellaPyMCSprint {material-sharp}`favorite;2em;sd-text-danger`
+:::
+
 
 ## Social Media Accounts
 
 | Organization   | Twitter  |  LinkedIn | Facebook | Instagram       | Discourse      |
 |----------------|----------|-----------|----------|-----------------|----------------|
 | Data Umbrella  | [@DataUmbrella](https://twitter.com/DataUmbrella) |  [dataumbrella](https://www.linkedin.com/company/dataumbrella/) | [data.umbrella.dei](https://www.facebook.com/data.umbrella.dei) | [@data.umbrella](https://www.instagram.com/data.umbrella/)  | N/A | 
-| PyMC Dev  | [@DataUmbrella](https://twitter.com/pymc_devs) |  [pymc](https://www.linkedin.com/company/pymc/mycompany/) | N/A | [pymc.io](https://discourse.pymc.io)  |
+| PyMC Dev  | [@pymc_devs](https://twitter.com/pymc_devs) |  [pymc](https://www.linkedin.com/company/pymc/mycompany/) | N/A | N/A  |  [pymc.io](https://discourse.pymc.io)
 
 
 ## Share Our Events
@@ -20,7 +23,7 @@ Our event series can be shared in one or more of the following ways:
 - Event website: https://pymc-data-umbrella.xyz/en/latest/
 - Event registration form:  https://tinyurl.com/du-pymc-os-ws
 - Tweet:  https://twitter.com/DataUmbrella/status/1538875289652142080
-- LinkedIn post: ​​https://www.linkedin.com/feed/update/urn:li:activity:6944647561630662656/
+- LinkedIn post: [https://www.linkedin.com/feed/update/urn:li:activity:6944647561630662656/](https://www.linkedin.com/feed/update/urn:li:activity:6944647561630662656/)
 - Social media card:  https://raw.githubusercontent.com/pymc-devs/pymc-data-umbrella/main/_static/banner_2022_07/2022_07_banner_1280×640px.png
 - Meetup event: can share links or cross-post the event with your Meetup group
     - Pre-series Office Hours | Jul 2 (Saturday) | 13 UTC | 1 hour | [MeetUp](https://www.meetup.com/data-umbrella/events/286552154/)
@@ -51,6 +54,8 @@ Our event series can be shared in one or more of the following ways:
 - Data Umbrella: [Brand and Logo](https://github.com/data-umbrella/info)
 - PyMC Devs:  [Brand & Logo](https://github.com/pymc-devs/brand)
 
-### Acknowledgment
+---
+
+**Acknowledgement**
 
 We would like to thank [Pollicy](https://pollicy.org) for sharing their [DataFest Africa](https://datafest.africa) media kit as a resource to the community.

--- a/2022-07_sprint/sprint_parties/media_kit.md
+++ b/2022-07_sprint/sprint_parties/media_kit.md
@@ -1,0 +1,56 @@
+# Social Media Kit
+
+(media_kit)=
+
+## Event Hashtag
+
+#DataUmbrellaPyMCSprint
+
+## Social Media Accounts
+
+| Organization   | Twitter  |  LinkedIn | Facebook | Instagram       | Discourse      |
+|----------------|----------|-----------|----------|-----------------|----------------|
+| Data Umbrella  | [@DataUmbrella](https://twitter.com/DataUmbrella) |  [dataumbrella](https://www.linkedin.com/company/dataumbrella/) | [data.umbrella.dei](https://www.facebook.com/data.umbrella.dei) | [@data.umbrella](https://www.instagram.com/data.umbrella/)  | N/A | 
+| PyMC Dev  | [@DataUmbrella](https://twitter.com/pymc_devs) |  [pymc](https://www.linkedin.com/company/pymc/mycompany/) | N/A | [pymc.io](https://discourse.pymc.io)  |
+
+
+## Share Our Events
+
+Our event series can be shared in one or more of the following ways:  
+- Event website: https://pymc-data-umbrella.xyz/en/latest/
+- Event registration form:  https://tinyurl.com/du-pymc-os-ws
+- Tweet:  https://twitter.com/DataUmbrella/status/1538875289652142080
+- LinkedIn post: ​​https://www.linkedin.com/feed/update/urn:li:activity:6944647561630662656/
+- Social media card:  https://raw.githubusercontent.com/pymc-devs/pymc-data-umbrella/main/_static/banner_2022_07/2022_07_banner_1280×640px.png
+- Meetup event: can share links or cross-post the event with your Meetup group
+    - Pre-series Office Hours | Jul 2 (Saturday) | 13 UTC | 1 hour | [MeetUp](https://www.meetup.com/data-umbrella/events/286552154/)
+    - Working Session #1      | Jul 9 (Saturday) | 13 UTC | 3 hours| [MeetUp](https://www.meetup.com/data-umbrella/events/286552452/)
+    - Working Session #2      | Jul 22 (Friday)  | 16 UTC | 3 hours| [MeetUp](https://www.meetup.com/data-umbrella/events/286628677/)
+    - Working Session #3      | Aug 4/5 (Th/Fr)  | 23 UTC  | 3 hours | [MeetUp](https://www.meetup.com/data-umbrella/events/286628723/)
+    - Post-series Office Hours [^1] | Aug 18 (Sat) | 23 UTC| 1 hour  | [MeetUp](https://www.meetup.com/data-umbrella/events/286628791/)
+- Email copy (button to copy all text available at the top right of the code block)
+
+  ```none
+  We [insert org name] are excited to share that we are a Community Partner with Data Umbrella for their upcoming open source working sessions with the Python library PyMC.  PyMC is an open-source probabilistic programming language in Python.
+
+  This is a beginner-friendly event.  Skills that are helpful to have: Git, GitHub, Markdown, Sphinx, statistics, python, Bayesian statistics.
+
+  Additionally, we have a series of videos where participants can watch videos and add timestamps. There are lots of ways to participate and contribute to open source.
+
+  More information on joining the event:
+  a) Schedule of events: https://pymc-data-umbrella.xyz/en/latest/2022-07_sprint/schedule.html
+  b) Complete this registration form: https://tinyurl.com/du-pymc-os-ws
+  ```
+### Channels to Share
+- Communication servers: Slack, Discord
+- Social media: Facebook, Instagram
+- Mobile communities: WhatsApp, Telegram
+- Newsletters
+
+## Logos
+- Data Umbrella: [Brand and Logo](https://github.com/data-umbrella/info)
+- PyMC Devs:  [Brand & Logo](https://github.com/pymc-devs/brand)
+
+### Acknowledgment
+
+We would like to thank [Pollicy](https://pollicy.org) for sharing their [DataFest Africa](https://datafest.africa) media kit as a resource to the community.

--- a/2022-07_sprint/sprint_parties/media_kit.md
+++ b/2022-07_sprint/sprint_parties/media_kit.md
@@ -13,13 +13,13 @@ This is our official hashtag and can be used on social media (Twitter, LinkedIn,
 
 | Organization   | Twitter  |  LinkedIn | Facebook | Instagram       | Discourse      |
 |----------------|----------|-----------|----------|-----------------|----------------|
-| Data Umbrella  | [@DataUmbrella](https://twitter.com/DataUmbrella) |  [dataumbrella](https://www.linkedin.com/company/dataumbrella/) | [data.umbrella.dei](https://www.facebook.com/data.umbrella.dei) | [@data.umbrella](https://www.instagram.com/data.umbrella/)  | N/A | 
-| PyMC Dev  | [@pymc_devs](https://twitter.com/pymc_devs) |  [pymc](https://www.linkedin.com/company/pymc/mycompany/) | N/A | N/A  |  [pymc.io](https://discourse.pymc.io)
+| Data Umbrella  | [@DataUmbrella](https://twitter.com/DataUmbrella) |  [dataumbrella](https://www.linkedin.com/company/dataumbrella/) | [data.umbrella.dei](https://www.facebook.com/data.umbrella.dei) | [@data.umbrella](https://www.instagram.com/data.umbrella/)  | N/A |
+| PyMC  | [@pymc_devs](https://twitter.com/pymc_devs) |  [pymc](https://www.linkedin.com/company/pymc/mycompany/) | N/A | N/A  |  [discourse.pymc.io](https://discourse.pymc.io)
 
 
 ## Share Our Events
 
-Our event series can be shared in one or more of the following ways:  
+Our event series can be shared in one or more of the following ways:
 - Event website: https://pymc-data-umbrella.xyz/en/latest/
 - Event registration form:  https://tinyurl.com/du-pymc-os-ws
 - Tweet:  https://twitter.com/DataUmbrella/status/1538875289652142080

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -53,7 +53,7 @@ Create Tweet {fab}`twitter`
 :::
 ::::
 
-There are social media links and text available in the {ref}`Community Partner section <become_community_partner>` which can be shared as well. 
+There are social media links and text available in our {ref}`Social Media Kit`<media_kit> with information for sharing with your network.
 
 ### Some outreach related advise
 

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -9,7 +9,7 @@ self
 ../about/contributing_to_pymc/index
 ../about/contributing_to_documentation/index
 donate
-../../sprint_parties/media_kit
+../2022-07_sprint/sprint_parties/media_kit
 :::
 
 ## Help us improve this website
@@ -54,7 +54,7 @@ Create Tweet {fab}`twitter`
 :::
 ::::
 
-There are social media links and text available in our {ref}`Social Media Kit`<media_kit> with information for sharing with your network.
+There are social media links and text available in our {ref}`media_kit` with information for sharing with your network.
 
 ### Some outreach related advise
 

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -9,6 +9,7 @@ self
 ../about/contributing_to_pymc/index
 ../about/contributing_to_documentation/index
 donate
+../../sprint_parties/media_kit
 :::
 
 ## Help us improve this website


### PR DESCRIPTION
Adding text for social media kit.
Moved to its own file.
Removed sharing text from community partners page. 

cc:  @OriolAbril @symeneses 