### PR TITLE
add alternate links to html head

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,0 +1,9 @@
+{% extends "pydata_sphinx_theme/layout.html" %}
+
+{% block extrahead %}
+{{ super() }}
+{% set file_path = pagename + '.html' %}
+<link rel="alternate" hreflang="en" href="https://pymc-data-umbrella.xyz/en/latest/{{ file_path }}" />
+<link rel="alternate" hreflang="es" href="https://pymc-data-umbrella.xyz/es/latest/{{ file_path }}" />
+<link rel="alternate" hreflang="pt" href="https://pymc-data-umbrella.xyz/pt/latest/{{ file_path }}" />
+{% endblock extrahead %}


### PR DESCRIPTION
Today I learned about the hreflang from softcatalà, an organization working on Catalan content and
tools in the web and computer programs.

This will add these tags to each page. From my very limited search about this feature,
it should help search engines show the user the page in their language straight
away. Ref: https://developers.google.com/search/docs/specialty/international/localized-versions#html
