### PR TITLE
add instructions page for translations

### DIFF
--- a/contributing/index.md
+++ b/contributing/index.md
@@ -71,7 +71,7 @@ There are social media links and text available in our {ref}`media_kit` with inf
 
 ## Language translations
 
-We are translating the website from English to other languages. The first couple of languages we are focusing on are Spanish and Portuguese: {ref}`translations`
+We are translating the website from English to other languages. The first couple of languages we are focusing on are Spanish and Portuguese. For more detailed instructions on how you can submit translations, see {ref}`translations`.
 
 If you are interested in translating to another language, please open up an [issue](https://github.com/pymc-devs/pymc-data-umbrella/issues) with any suggestions.
 

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -69,7 +69,7 @@ There are social media links and text available in our {ref}`media_kit` with inf
   to avoid "tutorials" as it can be confusing with the content of the documentation webinar.
   If you need some alternative to "webinar" consider using "event" or "workshop" before for example.
 
-## Translating content: volunteers needed 🙌
+## Language translations
 
 We are translating the website from English to other languages. The first couple of languages we are focusing on are Spanish and Portuguese: {ref}`translations`
 

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -71,8 +71,7 @@ There are social media links and text available in our {ref}`media_kit` with inf
 
 ## Translating content: volunteers needed 🙌
 
-:::{note}
-We first need to set up the translation infrastructure with sphinx. If you know how to do it or are interested in translating, please reach out.
+We are translating the website from English to other languages. The first couple of languages we are focusing on are Spanish and Portuguese: {ref}`translations`
 
-In the meantime, if you would to volunteer for translations, please add your information to [Issue #99](https://github.com/pymc-devs/pymc-data-umbrella/issues/99) on GitHub. We will be in touch when we are ready to move forward on this project.
-:::
+If you are interested in translating to another language, please open up an [issue](https://github.com/pymc-devs/pymc-data-umbrella/issues) with any suggestions.
+

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -17,7 +17,7 @@ language-translations
 
 If you find any errors or have any suggestions, please let us know! You can either [report an issue](https://github.com/pymc-devs/pymc-data-umbrella/issues/new) or send us a pull request.
 
-1. Click in the GitHub icon in the top right corner of the page to visit the page repo.
+1. Click on the GitHub icon in the top right corner of the page to visit the page repo.
 
 2. Fork and clone the repository.
 
@@ -74,4 +74,3 @@ There are social media links and text available in our {ref}`media_kit` with inf
 We are translating the website from English to other languages. The first couple of languages we are focusing on are Spanish and Portuguese. For more detailed instructions on how you can submit translations, see {ref}`translations`.
 
 If you are interested in translating to another language, please open up an [issue](https://github.com/pymc-devs/pymc-data-umbrella/issues) with any suggestions.
-

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -10,6 +10,7 @@ self
 ../about/contributing_to_documentation/index
 donate
 ../2022-07_sprint/sprint_parties/media_kit
+language-translations
 :::
 
 ## Help us improve this website

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -6,6 +6,7 @@
 :hidden:
 
 self
+videos
 ../about/contributing_to_pymc/index
 ../about/contributing_to_documentation/index
 donate

--- a/contributing/language-translations.md
+++ b/contributing/language-translations.md
@@ -27,14 +27,13 @@ Note: You can use your GitHub account to authenticate and log in to Transifex.
 6. You can translate sub-sections and "Save translation."  
 
 :::{note}
-There is a GitHub Actions that is configured on this repository, which turns a translation into a pull request whih is submitted to the repository. [PR #166](https://github.com/pymc-devs/pymc-data-umbrella/pull/166/files) is an example pull request. 
+There is a GitHub Actions that is configured on this repository, which turns a translation into a pull request which is submitted to the repository. [PR #166](https://github.com/pymc-devs/pymc-data-umbrella/pull/166/files) is an example pull request. 
 :::
 
 ## Translating content: volunteers needed
 
-:::{note}
 If you would to volunteer for translations, please select a page on [Issue #99](https://github.com/pymc-devs/pymc-data-umbrella/issues/99) on GitHub and indicate which page you will translate. A comment can be added to the issue.  This will let other contributors know so that work is not duplicated.
-:::
+
 
 ## Thank you 🙌
 

--- a/contributing/language-translations.md
+++ b/contributing/language-translations.md
@@ -6,7 +6,7 @@
 - Knowledge of English and (Spanish or Portuguese)
 
 ## About
-We are using [Transifex](https://www.transifex.com/) to manage the language translations, which provides a tranlsation infrastructure with Sphinx. Transifex is *a global content repository with a REST API, SDKs, automation, and more so you can centrally manage your source content and translations and build amazing multilingual digital experiences for your users.*
+We are using [Transifex](https://www.transifex.com/) to manage the language translations, which provides a translation infrastructure with Sphinx. Transifex is *a global content repository with a REST API, SDKs, automation, and more so you can centrally manage your source content and translations and build amazing multilingual digital experiences for your users.*
 
 ## Workflow
 

--- a/contributing/language-translations.md
+++ b/contributing/language-translations.md
@@ -31,7 +31,7 @@ There is GitHub Actions that is configured on this repository, which turns a tra
 
 ## Translating content: volunteers needed
 
-If you would like to volunteer for translations, please select a page on [Issue #99](https://github.com/pymc-devs/pymc-data-umbrella/issues/99) on GitHub and indicate which page you will translate. A comment can be added to the issue.  This will let other contributors know so that work is not duplicated.
+If you would like to volunteer for translations, please select a page.  We have included a list of priority pages to translate on [Issue #99](https://github.com/pymc-devs/pymc-data-umbrella/issues/99). 
 
 ## Thank you 🙌
 

--- a/contributing/language-translations.md
+++ b/contributing/language-translations.md
@@ -3,16 +3,15 @@
 
 ## Requirements
 - GitHub account
-- Knowledge of English and (Spanish or Portuguese)
+- Knowledge of English
+- Knowledge of Spanish or Portuguese
 
 ## About
 We are using [Transifex](https://www.transifex.com/) to manage the language translations, which provides a translation infrastructure with Sphinx. Transifex is *a global content repository with a REST API, SDKs, automation, and more so you can centrally manage your source content and translations and build amazing multilingual digital experiences for your users.*
 
 ## Workflow
 
-1.  Create a [Transifex account](https://www.transifex.com/signin/).
-
-Note: You can use your GitHub account to authenticate and log in to Transifex. 
+1.  Create a [Transifex account](https://www.transifex.com/signin/).  Note: You can use your GitHub account to authenticate and log in to Transifex.
 
 2.  Navigate to our project website:  [pymc/data-umbrella-sprints-website](https://www.transifex.com/pymc/data-umbrella-sprints-website/)
 
@@ -24,16 +23,15 @@ Note: You can use your GitHub account to authenticate and log in to Transifex.
 
 5. Pages to translate is a sub-menu under "Editor."  Currently, these pages are being prioritized for translation:  [priority pages](https://github.com/pymc-devs/pymc-data-umbrella/issues/99)
 
-6. You can translate sub-sections and "Save translation."  
+6. You can translate sub-sections and select "Save translation."  
 
 :::{note}
-There is a GitHub Actions that is configured on this repository, which turns a translation into a pull request which is submitted to the repository. [PR #166](https://github.com/pymc-devs/pymc-data-umbrella/pull/166/files) is an example pull request. 
+There is GitHub Actions that is configured on this repository, which turns a translation into a pull request which is submitted to the repository. [PR #166](https://github.com/pymc-devs/pymc-data-umbrella/pull/166/files) is an example pull request.
 :::
 
 ## Translating content: volunteers needed
 
-If you would to volunteer for translations, please select a page on [Issue #99](https://github.com/pymc-devs/pymc-data-umbrella/issues/99) on GitHub and indicate which page you will translate. A comment can be added to the issue.  This will let other contributors know so that work is not duplicated.
-
+If you would like to volunteer for translations, please select a page on [Issue #99](https://github.com/pymc-devs/pymc-data-umbrella/issues/99) on GitHub and indicate which page you will translate. A comment can be added to the issue.  This will let other contributors know so that work is not duplicated.
 
 ## Thank you 🙌
 

--- a/contributing/language-translations.md
+++ b/contributing/language-translations.md
@@ -18,24 +18,24 @@ Note: You can use your GitHub account to authenticate and log in to Transifex.
 
 3. Click on "Editor" in the top menu which will bring you to a list of pages of the website to translate:  https://www.transifex.com/pymc/data-umbrella-sprints-website/translate/
 
-4. In the top menu, choose "Select a language". Current options are: 
+4. In the top menu, choose "Select a language". Current options are:
     - Portuguese (pt)
     - Spanish (es)
 
-5. Pages to translate is a sub-menu under "Editor."  Currently, these pages are being prioritized for translation:  [priority pages](https://github.com/pymc-devs/pymc-data-umbrella/issues/99).
+5. Pages to translate is a sub-menu under "Editor."  Currently, these pages are being prioritized for translation:  [priority pages](https://github.com/pymc-devs/pymc-data-umbrella/issues/99)
 
 6. You can translate sub-sections and "Save translation."  
 
-:::{tip}
-GitHub Actions is configued on this repository.  Once per week, it will automatically accept the translations. 
+:::{note}
+There is a GitHub Actions that is configured on this repository, which turns a translation into a pull request whih is submitted to the repository. [PR #166](https://github.com/pymc-devs/pymc-data-umbrella/pull/166/files) is an example pull request. 
 :::
 
 ## Translating content: volunteers needed 🙌
 
 :::{note}
-If you would to volunteer for translations, please select a page on [Issue #99](https://github.com/pymc-devs/pymc-data-umbrella/issues/99) on GitHub and indicate which page you will translate. A comment can be added to the issue.  This will let other contributors know so that work is not duplicated. 
+If you would to volunteer for translations, please select a page on [Issue #99](https://github.com/pymc-devs/pymc-data-umbrella/issues/99) on GitHub and indicate which page you will translate. A comment can be added to the issue.  This will let other contributors know so that work is not duplicated.
 :::
 
 ## Thank you 🙌
 
-Thank you for your contributions and making this website accessible to more users. 
+Thank you for your contributions and making this website accessible to more users.

--- a/contributing/language-translations.md
+++ b/contributing/language-translations.md
@@ -1,0 +1,41 @@
+(translations)=
+# Language Translations
+
+## Requirements
+- GitHub account
+- Knowledge of English and (Spanish or Portuguese)
+
+## About
+We are using [Transifex](https://www.transifex.com/) to manage the language translations, which provides a tranlsation infrastructure with Sphinx. Transifex is *a global content repository with a REST API, SDKs, automation, and more so you can centrally manage your source content and translations and build amazing multilingual digital experiences for your users.*
+
+## Workflow
+
+1.  Create a [Transifex account](https://www.transifex.com/signin/).
+
+Note: You can use your GitHub account to authenticate and log in to Transifex. 
+
+2.  Navigate to our project website:  [pymc/data-umbrella-sprints-website](https://www.transifex.com/pymc/data-umbrella-sprints-website/)
+
+3. Click on "Editor" in the top menu which will bring you to a list of pages of the website to translate:  https://www.transifex.com/pymc/data-umbrella-sprints-website/translate/
+
+4. In the top menu, choose "Select a language". Current options are: 
+    - Portuguese (pt)
+    - Spanish (es)
+
+5. Pages to translate is a sub-menu under "Editor."  Currently, these pages are being prioritized for translation:  [priority pages](https://github.com/pymc-devs/pymc-data-umbrella/issues/99).
+
+6. You can translate sub-sections and "Save translation."  
+
+:::{tip}
+GitHub Actions is configued on this repository.  Once per week, it will automatically accept the translations. 
+:::
+
+## Translating content: volunteers needed 🙌
+
+:::{note}
+If you would to volunteer for translations, please select a page on [Issue #99](https://github.com/pymc-devs/pymc-data-umbrella/issues/99) on GitHub and indicate which page you will translate. A comment can be added to the issue.  This will let other contributors know so that work is not duplicated. 
+:::
+
+## Thank you 🙌
+
+Thank you for your contributions and making this website accessible to more users. 

--- a/contributing/language-translations.md
+++ b/contributing/language-translations.md
@@ -30,7 +30,7 @@ Note: You can use your GitHub account to authenticate and log in to Transifex.
 There is a GitHub Actions that is configured on this repository, which turns a translation into a pull request whih is submitted to the repository. [PR #166](https://github.com/pymc-devs/pymc-data-umbrella/pull/166/files) is an example pull request. 
 :::
 
-## Translating content: volunteers needed 🙌
+## Translating content: volunteers needed
 
 :::{note}
 If you would to volunteer for translations, please select a page on [Issue #99](https://github.com/pymc-devs/pymc-data-umbrella/issues/99) on GitHub and indicate which page you will translate. A comment can be added to the issue.  This will let other contributors know so that work is not duplicated.

--- a/contributing/language-translations.md
+++ b/contributing/language-translations.md
@@ -2,7 +2,7 @@
 # Language Translations
 
 ## Requirements
-- GitHub account
+- Transifex account (or GitHub one to log in with it) 
 - Knowledge of English
 - Knowledge of Spanish or Portuguese
 

--- a/contributing/videos.md
+++ b/contributing/videos.md
@@ -1,0 +1,18 @@
+(videos)=
+# Contribute timestamps to videos
+
+## Requirements
+- GitHub account
+- Markdown
+
+## About: why we are adding timestamps
+
+We have a collection of videos on YouTube from PyMCon 2020 and PyMCon Web Series.
+
+:stopwatch: We are adding timestamps to the PyMC YouTube videos.  When timestamps are available:
+1. It makes it easy for viewers to get to the part in the video they are interested in.
+2. It also helps potential viewers find the video based on their search terms.
+
+## Workflow
+
+Complete instructions are available in [Issue 11: adding timestamps to videos](https://github.com/pymc-devs/video-timestamps/issues/11).

--- a/contributing/videos.md
+++ b/contributing/videos.md
@@ -9,7 +9,7 @@
 
 We have a collection of videos on YouTube from PyMCon 2020 and PyMCon Web Series.
 
-:stopwatch: We are adding timestamps to the PyMC YouTube videos.  When timestamps are available:
+We are adding timestamps to the PyMC YouTube videos.  When timestamps are available:
 1. It makes it easy for viewers to get to the part in the video they are interested in.
 2. It also helps potential viewers find the video based on their search terms.
 


### PR DESCRIPTION
On the DU PyMC sprint website, now that the Transifex sphinx infrastructure has been set up, instructions are being provided.

Towards #174 
References #99 

cc:  @symeneses @Cristinamulas 