### PR TITLE
add new pages to transifex

### DIFF
--- a/.github/workflows/rtd-preview-link.yml
+++ b/.github/workflows/rtd-preview-link.yml
@@ -1,4 +1,5 @@
 name: Read the Docs Pull Request Preview
+
 on:
   pull_request_target:
     types:
@@ -15,15 +16,15 @@ jobs:
         language: [en, es, pt]
         include:
           - language: en
-            slug: ""
+            project: "pymc-data-umbrella"
           - language: es
-            slug: "-es"
+            project: "pymc-data-umbrella-es"
           - language: pt
-            slug: "-pt"
+            project: "pymc-data-umbrella-pt"
     runs-on: ubuntu-latest
     steps:
       - uses: readthedocs/actions/preview@v1
         with:
-          project-slug: "pymc-data-umbrella${{ matrix.suffix }}"
+          project-slug: "${{ matrix.project }}"
           message-template: ":books: Documentation preview ${{ matrix.language }} :books:: {docs-pr-index-url}"
           project-language: ${{ matrix.language }}

--- a/.tx/config
+++ b/.tx/config
@@ -259,3 +259,66 @@ source_file   = gettext/about/probabilistic_programming_with_pymc/index.pot
 type          = PO
 minimum_perc  = 0
 resource_name = about/probabilistic_programming_with_pymc/index
+
+[o:pymc:p:data-umbrella-sprints-website:r:contributing_language-translations]
+file_filter   = locales/<lang>/LC_MESSAGES/contributing/language-translations.po
+source_file   = gettext/contributing/language-translations.pot
+type          = PO
+minimum_perc  = 0
+resource_name = contributing/language-translations
+
+[o:pymc:p:data-umbrella-sprints-website:r:contributing_videos]
+file_filter   = locales/<lang>/LC_MESSAGES/contributing/videos.po
+source_file   = gettext/contributing/videos.pot
+type          = PO
+minimum_perc  = 0
+resource_name = contributing/videos
+
+[o:pymc:p:data-umbrella-sprints-website:r:2023-03_sprint_index]
+file_filter   = locales/<lang>/LC_MESSAGES/2023-03_sprint/index.po
+source_file   = gettext/2023-03_sprint/index.pot
+type          = PO
+minimum_perc  = 0
+resource_name = 2023-03_sprint/index
+
+[o:pymc:p:data-umbrella-sprints-website:r:2023-03_sprint_sprint_parties_media_kit]
+file_filter   = locales/<lang>/LC_MESSAGES/2023-03_sprint/sprint_parties/media_kit.po
+source_file   = gettext/2023-03_sprint/sprint_parties/media_kit.pot
+type          = PO
+minimum_perc  = 0
+resource_name = 2023-03_sprint/sprint_parties/media_kit
+
+[o:pymc:p:data-umbrella-sprints-website:r:2023-03_sprint_sprint_parties_index]
+file_filter   = locales/<lang>/LC_MESSAGES/2023-03_sprint/sprint_parties/index.po
+source_file   = gettext/2023-03_sprint/sprint_parties/index.pot
+type          = PO
+minimum_perc  = 0
+resource_name = 2023-03_sprint/sprint_parties/index
+
+[o:pymc:p:data-umbrella-sprints-website:r:2023-03_sprint_sprint_parties_community_partners]
+file_filter   = locales/<lang>/LC_MESSAGES/2023-03_sprint/sprint_parties/community_partners.po
+source_file   = gettext/2023-03_sprint/sprint_parties/community_partners.pot
+type          = PO
+minimum_perc  = 0
+resource_name = 2023-03_sprint/sprint_parties/community_partners
+
+[o:pymc:p:data-umbrella-sprints-website:r:2023-03_sprint_sprint_parties_contributors]
+file_filter   = locales/<lang>/LC_MESSAGES/2023-03_sprint/sprint_parties/contributors.po
+source_file   = gettext/2023-03_sprint/sprint_parties/contributors.pot
+type          = PO
+minimum_perc  = 0
+resource_name = 2023-03_sprint/sprint_parties/contributors
+
+[o:pymc:p:data-umbrella-sprints-website:r:2023-03_sprint_sprint_parties_organizers]
+file_filter   = locales/<lang>/LC_MESSAGES/2023-03_sprint/sprint_parties/organizers.po
+source_file   = gettext/2023-03_sprint/sprint_parties/organizers.pot
+type          = PO
+minimum_perc  = 0
+resource_name = 2023-03_sprint/sprint_parties/organizers
+
+[o:pymc:p:data-umbrella-sprints-website:r:2023-03_sprint_sprint_parties_sponsors]
+file_filter   = locales/<lang>/LC_MESSAGES/2023-03_sprint/sprint_parties/sponsors.po
+source_file   = gettext/2023-03_sprint/sprint_parties/sponsors.pot
+type          = PO
+minimum_perc  = 0
+resource_name = 2023-03_sprint/sprint_parties/sponsors

--- a/flag_old_files.py
+++ b/flag_old_files.py
@@ -1,0 +1,12 @@
+import glob
+
+with open(".tx/config", mode="r", encoding="utf-8") as f:
+    tx_config_orig = f.read()
+
+existing_filenames = list(glob.glob("gettext/**/*.pot", recursive=True))
+
+for line in tx_config_orig.split("\n"):
+    if line.startswith("source_file"):
+        filename = line.split("=")[1].strip()
+        if filename not in existing_filenames:
+            print(f"Unable to find {filename} from tx config in existing files")


### PR DESCRIPTION
Whenever we update files, changes are automatically pushed to transifex so things
are kept always up to date. For new files however we need to run a script manually.

This runs this script to update the transifex configuration to include the new sources,
and also adds a new script to flag files that should be removed from the tx config (deleted or
renamed).


<!-- readthedocs-preview pymc-data-umbrella start -->
:books: Documentation preview pt :books:: https://pymc-data-umbrella--201.org.readthedocs.build/pt/201/
<!-- readthedocs-preview pymc-data-umbrella end -->