### PR TITLE
update rtd config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,15 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
 sphinx:
     configuration: conf.py
     fail_on_warning: false
 
 
 python:
-   version: "3.8"
    install:
    - requirements: requirements-docs.txt


### PR DESCRIPTION
This should fix the doc build I believe


<!-- readthedocs-preview pymc-data-umbrella start -->
:books: Documentation preview en :books:: https://pymc-data-umbrella--234.org.readthedocs.build/en/234/
<!-- readthedocs-preview pymc-data-umbrella end -->

<!-- readthedocs-preview pymc-data-umbrella-es start -->
:books: Documentation preview es :books:: https://pymc-data-umbrella-es--234.org.readthedocs.build/es/234/
<!-- readthedocs-preview pymc-data-umbrella-es end -->

<!-- readthedocs-preview pymc-data-umbrella-pt start -->
:books: Documentation preview pt :books:: https://pymc-data-umbrella-pt--234.org.readthedocs.build/pt/234/
<!-- readthedocs-preview pymc-data-umbrella-pt end -->